### PR TITLE
Especialização da classe Periodicidade

### DIFF
--- a/7182-master/Novo/ISUB.Domain/Entities/Procedimento.cs
+++ b/7182-master/Novo/ISUB.Domain/Entities/Procedimento.cs
@@ -5,7 +5,7 @@ namespace ISUB.Domain.Entities
 {
     public class Procedimento : Entity
     {
-        public Procedimento(string nome, int periodicidadePadrao, AreaNegocio areaNegocio, bool executaVariasVezes)
+        public Procedimento(string nome, PeriodicidadeMeses periodicidadePadrao, AreaNegocio areaNegocio, bool executaVariasVezes)
         {
             AddNotifications(
                 new Contract()
@@ -22,7 +22,7 @@ namespace ISUB.Domain.Entities
         }
 
         public string Nome { get; private set; }
-        public int PeriodicidadePadrao { get; private set; }
+        public PeriodicidadeMeses PeriodicidadePadrao { get; private set; }
         public AreaNegocio AreaNegocio { get; private set; }
         public bool ExecutaVariasVezes { get; private set; }
     }

--- a/7182-master/Novo/ISUB.Domain/Periodicidade.cs
+++ b/7182-master/Novo/ISUB.Domain/Periodicidade.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace ISUB.Domain
 {
@@ -16,6 +17,21 @@ namespace ISUB.Domain
             }
             this.duracao = duracao;
             this.duracaoEmDias = dias;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Periodicidade periodicidade &&
+                   duracao == periodicidade.duracao &&
+                   duracaoEmDias == periodicidade.duracaoEmDias;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1034465429;
+            hashCode = hashCode * -1521134295 + duracao.GetHashCode();
+            hashCode = hashCode * -1521134295 + duracaoEmDias.GetHashCode();
+            return hashCode;
         }
 
         public override string ToString()
@@ -47,6 +63,16 @@ namespace ISUB.Domain
         public static DateTime operator +(Periodicidade periodicidade, DateTime data)
         {
             return data + periodicidade;
+        }
+
+        public static bool operator ==(Periodicidade left, Periodicidade right)
+        {
+            return EqualityComparer<Periodicidade>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(Periodicidade left, Periodicidade right)
+        {
+            return !(left == right);
         }
     }
 }

--- a/7182-master/Novo/ISUB.Domain/Periodicidade.cs
+++ b/7182-master/Novo/ISUB.Domain/Periodicidade.cs
@@ -20,13 +20,15 @@ namespace ISUB.Domain
         public override bool Equals(object obj)
         {
             return obj is Periodicidade periodicidade &&
-                   duracao == periodicidade.duracao;
+                   duracao == periodicidade.duracao &&
+                   GetType() == periodicidade.GetType();
         }
 
         public override int GetHashCode()
         {
             int hashCode = 1034465429;
             hashCode = hashCode * -1521134295 + duracao.GetHashCode();
+            hashCode = hashCode * -1521134295 + GetType().GetHashCode();
             return hashCode;
         }
 

--- a/7182-master/Novo/ISUB.Domain/Periodicidade.cs
+++ b/7182-master/Novo/ISUB.Domain/Periodicidade.cs
@@ -3,12 +3,11 @@ using System.Collections.Generic;
 
 namespace ISUB.Domain
 {
-    public class Periodicidade
+    public abstract class Periodicidade
     {
         protected readonly int duracao;
-        private bool duracaoEmDias;
 
-        public Periodicidade(int duracao, bool dias = false)
+        public Periodicidade(int duracao)
         {
             if (duracao < 1)
             {
@@ -16,53 +15,31 @@ namespace ISUB.Domain
                 throw new ArgumentException(message);
             }
             this.duracao = duracao;
-            this.duracaoEmDias = dias;
         }
 
         public override bool Equals(object obj)
         {
             return obj is Periodicidade periodicidade &&
-                   duracao == periodicidade.duracao &&
-                   duracaoEmDias == periodicidade.duracaoEmDias;
+                   duracao == periodicidade.duracao;
         }
 
         public override int GetHashCode()
         {
             int hashCode = 1034465429;
             hashCode = hashCode * -1521134295 + duracao.GetHashCode();
-            hashCode = hashCode * -1521134295 + duracaoEmDias.GetHashCode();
             return hashCode;
         }
 
-        public override string ToString()
-        {
-            var strDuracao = $"{duracao} ";
-            if (duracaoEmDias)
-            {
-                strDuracao += (duracao > 1) ? "dias" : "dia";
-            }
-            else
-            {
-                strDuracao += (duracao > 1) ? "meses" : "mês";
-            }
-            return strDuracao;
-        }
+        protected abstract DateTime SomarComDateTime(DateTime data);
 
         public static DateTime operator +(DateTime data, Periodicidade periodicidade)
         {
-            if (periodicidade.duracaoEmDias)
-            {
-                return data.AddDays(periodicidade.duracao);
-            }
-            else
-            {
-                return data.AddMonths(periodicidade.duracao);
-            }
+            return periodicidade.SomarComDateTime(data);
         }
 
         public static DateTime operator +(Periodicidade periodicidade, DateTime data)
         {
-            return data + periodicidade;
+            return periodicidade.SomarComDateTime(data);
         }
 
         public static bool operator ==(Periodicidade left, Periodicidade right)

--- a/7182-master/Novo/ISUB.Domain/Periodicidade.cs
+++ b/7182-master/Novo/ISUB.Domain/Periodicidade.cs
@@ -5,7 +5,7 @@ namespace ISUB.Domain
 {
     public class Periodicidade
     {
-        private int duracao;
+        protected readonly int duracao;
         private bool duracaoEmDias;
 
         public Periodicidade(int duracao, bool dias = false)

--- a/7182-master/Novo/ISUB.Domain/PeriodicidadeDias.cs
+++ b/7182-master/Novo/ISUB.Domain/PeriodicidadeDias.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace ISUB.Domain
+{
+    public class PeriodicidadeDias : Periodicidade
+    {
+        public PeriodicidadeDias(int duracao) : base(duracao) { }
+
+        public override string ToString()
+        {
+            var strDuracao = $"{duracao} ";
+            strDuracao += (duracao > 1) ? "dias" : "dia";
+            return strDuracao;
+        }
+
+        public static DateTime operator +(DateTime data, PeriodicidadeDias periodicidade)
+        {
+            return data.AddDays(periodicidade.duracao);
+        }
+
+        public static DateTime operator +(PeriodicidadeDias periodicidade, DateTime data)
+        {
+            return data + periodicidade;
+        }
+    }
+}

--- a/7182-master/Novo/ISUB.Domain/PeriodicidadeDias.cs
+++ b/7182-master/Novo/ISUB.Domain/PeriodicidadeDias.cs
@@ -13,14 +13,9 @@ namespace ISUB.Domain
             return strDuracao;
         }
 
-        public static DateTime operator +(DateTime data, PeriodicidadeDias periodicidade)
+        protected override DateTime SomarComDateTime(DateTime data)
         {
-            return data.AddDays(periodicidade.duracao);
-        }
-
-        public static DateTime operator +(PeriodicidadeDias periodicidade, DateTime data)
-        {
-            return data + periodicidade;
+            return data.AddDays(duracao);
         }
     }
 }

--- a/7182-master/Novo/ISUB.Domain/PeriodicidadeMeses.cs
+++ b/7182-master/Novo/ISUB.Domain/PeriodicidadeMeses.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ISUB.Domain
+{
+    public class PeriodicidadeMeses : Periodicidade
+    {
+        public PeriodicidadeMeses(int duracao) : base(duracao) { }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PeriodicidadeMeses meses &&
+                   base.Equals(obj) &&
+                   duracao == meses.duracao;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 2000508250;
+            hashCode = hashCode * -1521134295 + base.GetHashCode();
+            hashCode = hashCode * -1521134295 + duracao.GetHashCode();
+            return hashCode;
+        }
+
+        public override string ToString()
+        {
+            var strDuracao = $"{duracao} ";
+            strDuracao += (duracao > 1) ? "meses" : "mês";
+            return strDuracao;
+        }
+
+        public static DateTime operator +(DateTime data, PeriodicidadeMeses periodicidade)
+        {
+            return data.AddMonths(periodicidade.duracao);
+        }
+
+        public static DateTime operator +(PeriodicidadeMeses periodicidade, DateTime data)
+        {
+            return data + periodicidade;
+        }
+
+        public static bool operator ==(PeriodicidadeMeses left, PeriodicidadeMeses right)
+        {
+            return EqualityComparer<PeriodicidadeMeses>.Default.Equals(left, right);
+        }
+
+        public static bool operator !=(PeriodicidadeMeses left, PeriodicidadeMeses right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/7182-master/Novo/ISUB.Domain/PeriodicidadeMeses.cs
+++ b/7182-master/Novo/ISUB.Domain/PeriodicidadeMeses.cs
@@ -1,26 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ISUB.Domain
 {
     public class PeriodicidadeMeses : Periodicidade
     {
         public PeriodicidadeMeses(int duracao) : base(duracao) { }
-
-        public override bool Equals(object obj)
-        {
-            return obj is PeriodicidadeMeses meses &&
-                   base.Equals(obj) &&
-                   duracao == meses.duracao;
-        }
-
-        public override int GetHashCode()
-        {
-            int hashCode = 2000508250;
-            hashCode = hashCode * -1521134295 + base.GetHashCode();
-            hashCode = hashCode * -1521134295 + duracao.GetHashCode();
-            return hashCode;
-        }
 
         public override string ToString()
         {
@@ -29,24 +13,9 @@ namespace ISUB.Domain
             return strDuracao;
         }
 
-        public static DateTime operator +(DateTime data, PeriodicidadeMeses periodicidade)
+        protected override DateTime SomarComDateTime(DateTime data)
         {
-            return data.AddMonths(periodicidade.duracao);
-        }
-
-        public static DateTime operator +(PeriodicidadeMeses periodicidade, DateTime data)
-        {
-            return data + periodicidade;
-        }
-
-        public static bool operator ==(PeriodicidadeMeses left, PeriodicidadeMeses right)
-        {
-            return EqualityComparer<PeriodicidadeMeses>.Default.Equals(left, right);
-        }
-
-        public static bool operator !=(PeriodicidadeMeses left, PeriodicidadeMeses right)
-        {
-            return !(left == right);
+            return data.AddMonths(duracao);
         }
     }
 }

--- a/7182-master/Novo/ISUB.Test/Entities/PlanejamentoTest.cs
+++ b/7182-master/Novo/ISUB.Test/Entities/PlanejamentoTest.cs
@@ -10,14 +10,14 @@ namespace ISUB.Tests.Domain
     [TestClass]
     public class PlanejamentoTests
     {
-        private Procedimento _procedimento = new Procedimento("TEADF", 12, AreaNegocio.Flexivel, true);
+        private Procedimento _procedimento = new Procedimento("TEADF", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true);
         private Objeto _objeto = new Objeto(AreaNegocio.Flexivel, "TR500101");
 
         [TestMethod]
         [TestCategory("Domain")]
         public void Dado_um_novo_planejamento_valido_ele_deve_gerar_um_numero_com_8_caracteres()
         {
-            Procedimento _procedimento = new Procedimento("TEADF", 12, AreaNegocio.Flexivel, true);
+            Procedimento _procedimento = new Procedimento("TEADF", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true);
             Objeto _objeto = new Objeto(AreaNegocio.Flexivel, "TR500101");
             List<Objeto> _objetos = new List<Objeto>();
             _objetos.Add(_objeto);

--- a/7182-master/Novo/ISUB.Test/Entities/PlanejamentoTest.cs
+++ b/7182-master/Novo/ISUB.Test/Entities/PlanejamentoTest.cs
@@ -22,7 +22,7 @@ namespace ISUB.Tests.Domain
             List<Objeto> _objetos = new List<Objeto>();
             _objetos.Add(_objeto);
 
-            var planejamento = new Planejamento(_objetos, _procedimento, new DateTime(2018, 01, 15), new Periodicidade(12));
+            var planejamento = new Planejamento(_objetos, _procedimento, new DateTime(2018, 01, 15), new PeriodicidadeMeses(12));
             Assert.AreEqual(36, planejamento.Id.ToString().Length);
         }
         /*

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeDiasTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeDiasTest.cs
@@ -82,6 +82,7 @@ namespace ISUB.Tests.Domain
             Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
             Assert.IsTrue(periodicidade == periodicidadeIgual);
             Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
+            Assert.AreNotSame(periodicidade, periodicidadeIgual);
         }
 
         [TestMethod]
@@ -89,7 +90,7 @@ namespace ISUB.Tests.Domain
         {
             // Arrange
             var periodicidade = new PeriodicidadeDias(365);
-            var periodicidadeDiferente = new PeriodicidadeMeses(12);
+            var periodicidadeDiferente = new PeriodicidadeDias(360);
 
             // Act & Assert
             Assert.IsFalse(periodicidade.Equals(periodicidadeDiferente));

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeDiasTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeDiasTest.cs
@@ -1,0 +1,100 @@
+﻿using ISUB.Domain;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace ISUB.Tests.Domain
+{
+    [TestClass]
+    public class PeriodicidadeDiasTest
+    {
+        [TestMethod]
+        public void TestExibicaoPeriodicidadeDias()
+        {
+            // Arrange
+            var seteDias = new PeriodicidadeDias(7);
+            var noventaDias = new PeriodicidadeDias(90);
+
+            // Act & Assert
+            Assert.AreEqual("7 dias", seteDias.ToString());
+            Assert.AreEqual("90 dias", noventaDias.ToString());
+        }
+
+        [TestMethod]
+        public void TestExibicaoPeriodicidadeNoSingular()
+        {
+            // Arrange
+            var umDia = new PeriodicidadeDias(1);
+
+            // Act & Assert
+            Assert.AreEqual("1 dia", umDia.ToString());
+        }
+
+        [TestMethod]
+        public void TestPeriodicidadeDeveSerPositiva()
+        {
+            // Arrange / Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => new PeriodicidadeDias(0),
+                "Periodicidade não pode ser zero.");
+            Assert.ThrowsException<ArgumentException>(() => new PeriodicidadeDias(-1),
+                "Periodicidade não pode ser negativa.");
+        }
+
+        [TestMethod]
+        public void TestSomaPeriodicidadeDiasComDateTime()
+        {
+            // Arrange
+            var dataInicio = new DateTime(2020, 04, 29);
+            var seteDias = new PeriodicidadeDias(7);
+            var dataEsperada = new DateTime(2020, 05, 06);
+
+            // Act
+            var dataPlanejada = dataInicio + seteDias;
+
+            // Assert
+            Assert.AreEqual(dataEsperada, dataPlanejada);
+        }
+
+        [TestMethod]
+        public void TestSomaPeriodicidadeComDateTimeDeveSerComutativa()
+        {
+            // Arrange
+            var dataInicio = new DateTime(2020, 04, 29);
+            var seteDias = new PeriodicidadeDias(7);
+            var dataEsperada = new DateTime(2020, 05, 06);
+
+            // Act
+            var dataPlanejada1 = dataInicio + seteDias;
+            var dataPlanejada2 = seteDias + dataInicio;
+
+            // Assert
+            Assert.AreEqual(dataEsperada, dataPlanejada1);
+            Assert.AreEqual(dataEsperada, dataPlanejada2);
+        }
+
+        [TestMethod]
+        public void TestIgualdade()
+        {
+            // Arrange
+            var periodicidade = new PeriodicidadeDias(365);
+            var periodicidadeIgual = new PeriodicidadeDias(365);
+
+            // Act & Assert
+            Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
+            Assert.IsTrue(periodicidade == periodicidadeIgual);
+            Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
+        }
+
+        [TestMethod]
+        public void TestDesigualdade()
+        {
+            // Arrange
+            var periodicidade = new PeriodicidadeDias(365);
+            var periodicidadeDiferente = new PeriodicidadeMeses(12);
+
+            // Act & Assert
+            Assert.IsFalse(periodicidade.Equals(periodicidadeDiferente));
+            Assert.IsTrue(periodicidade != periodicidadeDiferente);
+            Assert.AreNotEqual(periodicidade.GetHashCode(), periodicidadeDiferente.GetHashCode());
+        }
+    }
+}

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
@@ -1,0 +1,100 @@
+﻿using ISUB.Domain;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace ISUB.Tests.Domain
+{
+    [TestClass]
+    public class PeriodicidadeMesesTest
+    {
+        [TestMethod]
+        public void TestExibicaoPeriodicidadeMeses()
+        {
+            // Arrange
+            var cincoMeses = new PeriodicidadeMeses(5);
+            var sessentaMeses = new PeriodicidadeMeses(60);
+
+            // Act & Assert
+            Assert.AreEqual("5 meses", cincoMeses.ToString());
+            Assert.AreEqual("60 meses", sessentaMeses.ToString());
+        }
+
+        [TestMethod]
+        public void TestExibicaoPeriodicidadeNoSingular()
+        {
+            // Arrange
+            var umMes = new Periodicidade(1, dias: false);
+
+            // Act & Assert
+            Assert.AreEqual("1 mês", umMes.ToString());
+        }
+
+        [TestMethod]
+        public void TestPeriodicidadeDeveSerPositiva()
+        {
+            // Arrange / Act / Assert
+            Assert.ThrowsException<ArgumentException>(() => new PeriodicidadeMeses(0),
+                "Periodicidade não pode ser zero.");
+            Assert.ThrowsException<ArgumentException>(() => new PeriodicidadeMeses(-1),
+                "Periodicidade não pode ser negativa.");
+        }
+
+        [TestMethod]
+        public void TestSomaPeriodicidadeMesesComDateTime()
+        {
+            // Arrange
+            var dataInicio = new DateTime(2020, 05, 09);
+            var dozeMeses = new PeriodicidadeMeses(12);
+            var dataEsperada = new DateTime(2021, 05, 09);
+
+            // Act
+            var dataPlanejada = dataInicio + dozeMeses;
+
+            // Assert
+            Assert.AreEqual(dataEsperada, dataPlanejada);
+        }
+
+        [TestMethod]
+        public void TestSomaPeriodicidadeComDateTimeDeveSerComutativa()
+        {
+            // Arrange
+            var dataInicio = new DateTime(2020, 04, 29);
+            var seisMeses = new PeriodicidadeMeses(6);
+            var dataEsperada = new DateTime(2020, 10, 29);
+
+            // Act
+            var dataPlanejada1 = dataInicio + seisMeses;
+            var dataPlanejada2 = seisMeses + dataInicio;
+
+            // Assert
+            Assert.AreEqual(dataEsperada, dataPlanejada1);
+            Assert.AreEqual(dataEsperada, dataPlanejada2);
+        }
+
+        [TestMethod]
+        public void TestIgualdade()
+        {
+            // Arrange
+            var periodicidade = new PeriodicidadeMeses(6);
+            var periodicidadeIgual = new PeriodicidadeMeses(6);
+
+            // Act & Assert
+            Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
+            Assert.IsTrue(periodicidade == periodicidadeIgual);
+            Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
+        }
+
+        [TestMethod]
+        public void TestDesigualdade()
+        {
+            // Arrange
+            var periodicidade = new PeriodicidadeDias(365);
+            var periodicidadeDiferente = new PeriodicidadeMeses(12);
+
+            // Act & Assert
+            Assert.IsFalse(periodicidade.Equals(periodicidadeDiferente));
+            Assert.IsTrue(periodicidade != periodicidadeDiferente);
+            Assert.AreNotEqual(periodicidade.GetHashCode(), periodicidadeDiferente.GetHashCode());
+        }
+    }
+}

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
@@ -23,7 +23,7 @@ namespace ISUB.Tests.Domain
         public void TestExibicaoPeriodicidadeNoSingular()
         {
             // Arrange
-            var umMes = new Periodicidade(1, dias: false);
+            var umMes = new PeriodicidadeMeses(1);
 
             // Act & Assert
             Assert.AreEqual("1 mês", umMes.ToString());

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeMesesTest.cs
@@ -82,13 +82,14 @@ namespace ISUB.Tests.Domain
             Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
             Assert.IsTrue(periodicidade == periodicidadeIgual);
             Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
+            Assert.AreNotSame(periodicidade, periodicidadeIgual);
         }
 
         [TestMethod]
         public void TestDesigualdade()
         {
             // Arrange
-            var periodicidade = new PeriodicidadeDias(365);
+            var periodicidade = new PeriodicidadeMeses(6);
             var periodicidadeDiferente = new PeriodicidadeMeses(12);
 
             // Act & Assert

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
@@ -44,5 +44,17 @@ namespace ISUB.Tests.Domain
             Assert.AreEqual(dataEsperada1, dataPlanejada1);
             Assert.AreEqual(dataEsperada2, dataPlanejada2);
         }
+
+        [TestMethod]
+        public void TestPeriodicidadeDiasMesesComValorDuracaoIgualDevemSerDiferentes()
+        {
+            // Arrange
+            var sessentaMeses = new PeriodicidadeMeses(60);
+            var sessentaDias = new PeriodicidadeDias(60);
+
+            // Act & Assert
+            Assert.AreNotEqual(sessentaMeses, sessentaDias);
+            Assert.AreNotEqual(sessentaMeses.GetHashCode(), sessentaDias.GetHashCode());
+        }
     }
 }

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
@@ -8,106 +8,13 @@ namespace ISUB.Tests.Domain
     public class PeriodicidadeTest
     {
         [TestMethod]
-        public void TestExibicaoPeriodicidadeMeses()
-        {
-            // Arrange
-            var cincoMeses = new Periodicidade(5);
-            var sessentaMeses = new Periodicidade(60);
-
-            // Act & Assert
-            Assert.AreEqual("5 meses", cincoMeses.ToString());
-            Assert.AreEqual("60 meses", sessentaMeses.ToString());
-        }
-
-        [TestMethod]
-        public void TestExibicaoPeriodicidadeDias()
-        {
-            // Arrange
-            var seteDias = new Periodicidade(7, dias: true);
-            var noventaDias = new Periodicidade(90, dias: true);
-
-            // Act & Assert
-            Assert.AreEqual("7 dias", seteDias.ToString());
-            Assert.AreEqual("90 dias", noventaDias.ToString());
-        }
-
-        [TestMethod]
-        public void TestExibicaoPeriodicidadeNoSingular()
-        {
-            // Arrange
-            var umMes = new Periodicidade(1, dias: false);
-            var umDia = new Periodicidade(1, dias: true);
-
-            // Act & Assert
-            Assert.AreEqual("1 mês", umMes.ToString());
-            Assert.AreEqual("1 dia", umDia.ToString());
-        }
-
-        [TestMethod]
-        public void TestPeriodicidadeDeveSerPositiva()
-        {
-            // Arrange / Act / Assert
-            Assert.ThrowsException<ArgumentException>(() => new Periodicidade(0),
-                "Periodicidade não pode ser zero.");
-            Assert.ThrowsException<ArgumentException>(() => new Periodicidade(-1),
-                "Periodicidade não pode ser negativa.");
-        }
-
-        [TestMethod]
-        public void TestSomaPeriodicidadeMesesComDateTime()
-        {
-            // Arrange
-            var dataInicio = new DateTime(2020, 05, 09);
-            var dozeMeses = new Periodicidade(12);
-            var dataEsperada = new DateTime(2021, 05, 09);
-
-            // Act
-            var dataPlanejada = dataInicio + dozeMeses;
-
-            // Assert
-            Assert.AreEqual(dataEsperada, dataPlanejada);
-        }
-
-        [TestMethod]
-        public void TestSomaPeriodicidadeDiasComDateTime()
-        {
-            // Arrange
-            var dataInicio = new DateTime(2020, 04, 29);
-            var seteDias = new Periodicidade(7, dias: true);
-            var dataEsperada = new DateTime(2020, 05, 06);
-
-            // Act
-            var dataPlanejada = dataInicio + seteDias;
-
-            // Assert
-            Assert.AreEqual(dataEsperada, dataPlanejada);
-        }
-
-        [TestMethod]
-        public void TestSomaPeriodicidadeComDateTimeDeveSerComutativa()
-        {
-            // Arrange
-            var dataInicio = new DateTime(2020, 04, 29);
-            var seteDias = new Periodicidade(7, dias: true);
-            var dataEsperada = new DateTime(2020, 05, 06);
-
-            // Act
-            var dataPlanejada1 = dataInicio + seteDias;
-            var dataPlanejada2 = seteDias + dataInicio;
-
-            // Assert
-            Assert.AreEqual(dataEsperada, dataPlanejada1);
-            Assert.AreEqual(dataEsperada, dataPlanejada2);
-        }
-
-        [TestMethod]
         public void Test_30Dias_Nem_Sempre_Igual_UmMes()
         {
             // Arrange
             var dataInicio = new DateTime(2020, 05, 09);
-            var trintaDias = new Periodicidade(30, dias: true);
+            var trintaDias = new PeriodicidadeDias(30);
             var dataEsperada1 = new DateTime(2020, 06, 08);
-            var umMes = new Periodicidade(1);
+            var umMes = new PeriodicidadeMeses(1);
             var dataEsperada2 = new DateTime(2020, 06, 09);
 
             // Act
@@ -124,9 +31,9 @@ namespace ISUB.Tests.Domain
         {
             // Arrange
             var dataInicio = new DateTime(2019, 05, 09);
-            var umAno = new Periodicidade(365, dias: true);
+            var umAno = new PeriodicidadeDias(365);
             var dataEsperada1 = new DateTime(2020, 05, 08); // 2020 é bissexto.
-            var dozeMeses = new Periodicidade(12);
+            var dozeMeses = new PeriodicidadeMeses(12);
             var dataEsperada2 = new DateTime(2020, 05, 09);
 
             // Act
@@ -136,32 +43,6 @@ namespace ISUB.Tests.Domain
             // Assert
             Assert.AreEqual(dataEsperada1, dataPlanejada1);
             Assert.AreEqual(dataEsperada2, dataPlanejada2);
-        }
-
-        [TestMethod]
-        public void TestIgualdade()
-        {
-            // Arrange
-            var periodicidade = new Periodicidade(365, dias: true);
-            var periodicidadeIgual = new Periodicidade(365, dias: true);
-
-            // Act & Assert
-            Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
-            Assert.IsTrue(periodicidade == periodicidadeIgual);
-            Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
-        }
-
-        [TestMethod]
-        public void TestDesigualdade()
-        {
-            // Arrange
-            var periodicidade = new Periodicidade(365, dias: true);
-            var periodicidadeDiferente = new Periodicidade(12, dias: false);
-
-            // Act & Assert
-            Assert.IsFalse(periodicidade.Equals(periodicidadeDiferente));
-            Assert.IsTrue(periodicidade != periodicidadeDiferente);
-            Assert.AreNotEqual(periodicidade.GetHashCode(), periodicidadeDiferente.GetHashCode());
         }
     }
 }

--- a/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
+++ b/7182-master/Novo/ISUB.Test/PeriodicidadeTest.cs
@@ -137,5 +137,31 @@ namespace ISUB.Tests.Domain
             Assert.AreEqual(dataEsperada1, dataPlanejada1);
             Assert.AreEqual(dataEsperada2, dataPlanejada2);
         }
+
+        [TestMethod]
+        public void TestIgualdade()
+        {
+            // Arrange
+            var periodicidade = new Periodicidade(365, dias: true);
+            var periodicidadeIgual = new Periodicidade(365, dias: true);
+
+            // Act & Assert
+            Assert.IsTrue(periodicidade.Equals(periodicidadeIgual));
+            Assert.IsTrue(periodicidade == periodicidadeIgual);
+            Assert.AreEqual(periodicidade.GetHashCode(), periodicidadeIgual.GetHashCode());
+        }
+
+        [TestMethod]
+        public void TestDesigualdade()
+        {
+            // Arrange
+            var periodicidade = new Periodicidade(365, dias: true);
+            var periodicidadeDiferente = new Periodicidade(12, dias: false);
+
+            // Act & Assert
+            Assert.IsFalse(periodicidade.Equals(periodicidadeDiferente));
+            Assert.IsTrue(periodicidade != periodicidadeDiferente);
+            Assert.AreNotEqual(periodicidade.GetHashCode(), periodicidadeDiferente.GetHashCode());
+        }
     }
 }

--- a/7182-master/Novo/ISUB.Test/Repositories/FakePlanejamentoRepository.cs
+++ b/7182-master/Novo/ISUB.Test/Repositories/FakePlanejamentoRepository.cs
@@ -16,7 +16,7 @@ namespace ISUB.Test.Repositories
 
         public Planejamento Get(Guid Id)
         {
-            var planejamento = new Planejamento(_objetos, _procedimento, new DateTime(2018, 01, 15), new Periodicidade(12));
+            var planejamento = new Planejamento(_objetos, _procedimento, new DateTime(2018, 01, 15), new PeriodicidadeMeses(12));
             return planejamento;
         }
 

--- a/7182-master/Novo/ISUB.Test/Repositories/FakePlanejamentoRepository.cs
+++ b/7182-master/Novo/ISUB.Test/Repositories/FakePlanejamentoRepository.cs
@@ -9,7 +9,7 @@ namespace ISUB.Test.Repositories
 {
     public class FakePlanejamentoRepository : IPlanejamentoRepository
     {
-        private Procedimento _procedimento = new Procedimento("TEADF", 12, AreaNegocio.Flexivel, true);
+        private Procedimento _procedimento = new Procedimento("TEADF", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true);
         //private Objeto _objeto = new Objeto(AreaNegocio.Flexivel, "TR500101");
         private List<Objeto> _objetos = new List<Objeto>() { new Objeto(AreaNegocio.Flexivel, "TR500101") };
         //_objetos.Add(_objeto);

--- a/7182-master/Novo/ISUB.Test/Repositories/FakeProcedimentoRepository.cs
+++ b/7182-master/Novo/ISUB.Test/Repositories/FakeProcedimentoRepository.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using ISUB.Domain;
 using ISUB.Domain.Entities;
 using ISUB.Domain.Enum;
 using ISUB.Domain.Repositories.Interface;
+using System;
+using System.Collections.Generic;
 
 namespace ISUB.Test.Repositories
 {
@@ -15,12 +15,18 @@ namespace ISUB.Test.Repositories
         {
             var procedimentos = new List<Procedimento>();
 
-            Procedimentos.Add(new Procedimento("TEADF", 12, AreaNegocio.Flexivel, true));
-            Procedimentos.Add(new Procedimento("PIDF-1", 24, AreaNegocio.Rigido, true));
-            Procedimentos.Add(new Procedimento("PIDF-2", 36, AreaNegocio.TopSide, true));
-            Procedimentos.Add(new Procedimento("PIDR", 48, AreaNegocio.Faixa, true));
-            Procedimentos.Add(new Procedimento("EQSB", 60, AreaNegocio.Equipamento, true));
-            Procedimentos.Add(new Procedimento("PIG", 12, AreaNegocio.Flexivel, true));
+            Procedimentos.Add(
+                new Procedimento("TEADF", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true));
+            Procedimentos.Add(
+                new Procedimento("PIDF-1", new PeriodicidadeMeses(24), AreaNegocio.Rigido, true));
+            Procedimentos.Add(
+                new Procedimento("PIDF-2", new PeriodicidadeMeses(36), AreaNegocio.TopSide, true));
+            Procedimentos.Add(
+                new Procedimento("PIDR", new PeriodicidadeMeses(48), AreaNegocio.Faixa, true));
+            Procedimentos.Add(
+                new Procedimento("EQSB", new PeriodicidadeMeses(60), AreaNegocio.Equipamento, true));
+            Procedimentos.Add(
+                new Procedimento("PIG", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true));
 
             this.Procedimentos = procedimentos;
         }
@@ -28,7 +34,7 @@ namespace ISUB.Test.Repositories
         public IEnumerable<Procedimento> Get(IEnumerable<Guid> ids)
         {
             var Procedimentos = new List<Procedimento>();
-            Procedimentos.Add(new Procedimento("TEADF", 12, AreaNegocio.Flexivel, true));
+            Procedimentos.Add(new Procedimento("TEADF", new PeriodicidadeMeses(12), AreaNegocio.Flexivel, true));
             return Procedimentos;
         }
     }


### PR DESCRIPTION
Sequência de alterações para separar periodicidades em dias e em meses em classes diferentes. Isso permite restringir situações onde só um dos tipos de periodicidade é aceito, como no construtor do Procedimento, por exemplo.